### PR TITLE
Fix python path in code build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,13 +7,14 @@ env:
     VERSION: "22.03"
 phases:
   install:
-    runtime-versions:
-      python: 3.8
     commands:
       - echo "Installing dependencies"
       - apt-get update
+      - apt-get -y install build-essential libncurses5-dev libncursesw5-dev zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python2 python3
       - apt-get -y install --upgrade awscli
-      - apt-get -y install build-essential libncurses5-dev libncursesw5-dev zlib1g-dev gawk git gettext libssl-dev xsltproc rsync wget unzip python2
+      # remove pyenv from path to use the default system installation.
+      - export PATH=$(echo $PATH | sed 's@/root/.pyenv/shims:/root/.pyenv/bin:@@g')
+
   pre_build:
     commands:
       - cd $CODEBUILD_SRC_DIR


### PR DESCRIPTION
Code build uses pyenv python  path which is used in the build phase.
This PR changes the python path to use the system's path instead.