### PR TITLE
Added 3 changes:

### DIFF
--- a/onion_buildenv
+++ b/onion_buildenv
@@ -12,11 +12,15 @@ BUILD_DIR="$PWD"
 
 TARGET_IMAGE_BUILDER_DIR="$BUILD_DIR/openwrt-imagebuilder"
 IMAGE_BUILDER_ZIP="$BUILD_DIR/${IMAGE_BUILDER_URL##*/}"
+IMAGE_BUILDER_USER_FILES="$TARGET_IMAGE_BUILDER_DIR/files"
 IMAGE_BUILDER_FILE="${IMAGE_BUILDER_ZIP//.tar.xz}"
 OUTPUT_DIR="$PWD/output"
 
-DATE=$(date +"%Y%m%d")
-VERSION_INFO="${OPENWRT_VERSION}-${DATE}"
+if [ -z $DATE_VERSION ] || [ $DATE_VERSION == "y" ]; then  
+	DATE=$(date +"-%Y%m%d")
+fi
+
+VERSION_INFO="${OPENWRT_VERSION}${DATE}"
 
 download_file() {
 	local url=$1
@@ -90,8 +94,16 @@ download_builder() {
 	return 0
 }
 
+
+clean_additions() {
+	if [ -n "$IMAGE_BUILDER_USER_FILES" ] && [ -d "$IMAGE_BUILDER_USER_FILES" ]; then
+		rm -rf "$IMAGE_BUILDER_USER_FILES" || return 1
+	fi
+}
+
 prepare_imagebuilder() {
 	echo "> Preparing Image Builder"
+	clean_additions	
 	if [ -n "$ADDITIONS_DIR" ] && [ -d "$ADDITIONS_DIR" ]; then
 		cp -a $ADDITIONS_DIR/* $TARGET_IMAGE_BUILDER_DIR
 	fi
@@ -103,9 +115,15 @@ update_package_repos() {
 
 	[ -z "$PACKAGE_REPOS" ] && return 0
 
-	echo -e "$PACKAGE_REPOS" > $TARGET_IMAGE_BUILDER_DIR/repositories.conf
-	cat $TARGET_IMAGE_BUILDER_DIR/repositories.conf.org >> $TARGET_IMAGE_BUILDER_DIR/repositories.conf
-
+	## Add packages from th profile but filter out those we want to remove
+	echo -e "$PACKAGE_REPOS" | grep -v -e "^\-" >  $TARGET_IMAGE_BUILDER_DIR/repositories.conf
+	
+	## Create the grep filter for any packages in the profile with a leading '-' symbol to be filtered out
+	EXCLUDES=$(echo -e  "$PACKAGE_REPOS" | grep "^\-" | awk -F" " '{ print $2 }')
+	for EX in $EXCLUDES; do EXCLUDE_CMD="$EXCLUDE_CMD -e $EX"; done
+	
+	## Filter the original opwenwrt sdk repo list to remove those we want to remove
+	cat $TARGET_IMAGE_BUILDER_DIR/repositories.conf.org | grep -v $EXCLUDE_CMD >> $TARGET_IMAGE_BUILDER_DIR/repositories.conf
 	return 0
 }
 
@@ -184,6 +202,7 @@ commands="
 setup_imagebuilder
 update_imagebuilder
 clean_imagebuilder
+update_package_repos
 build_firmware
 build_all_firmware
 "

--- a/profile
+++ b/profile
@@ -6,6 +6,7 @@ OPENWRT_VERSION="${OPENWRT_RELEASE}.3"
 ARCH="mipsel_24kc"
 TARGET="ramips"
 SUBTARGET="mt76x8"
+DATE_VERSION="n"
 
 # Default base URL from where openwrt SDKs are available for the respective openwrt version and targets
 # BASE_URL="https://downloads.openwrt.org/releases/$OPENWRT_VERSION/targets/$TARGET/$SUBTARGET"
@@ -29,6 +30,9 @@ src/gz onion_packages http://downloads.onioniot.com/releases/$OPENWRT_VERSION/pa
 src/gz onion_routing http://downloads.onioniot.com/releases/$OPENWRT_VERSION/packages/$ARCH/routing
 src/gz onion_telephony http://downloads.onioniot.com/releases/$OPENWRT_VERSION/packages/$ARCH/telephony
 src/gz onion_openwrt_packages http://repo.onioniot.com/omega2/packages/openwrt-$OPENWRT_VERSION/onion
+src/gz onion_openwrt_packages_core http://repo.onioniot.com/omega2/packages/openwrt-$OPENWRT_VERSION/core
+-src/gz openwrt_luci
+-src/gz openwrt_telephony
 "
 
 # PACKAGE_REPOS="
@@ -43,6 +47,30 @@ omega2-base-files
 omega2-base-passwd
 omega2-ctrl
 i2c-tools
+openssh-sftp-server
+libsqlite3
+libubox
+libubus
+ubox
+ubus
+dosfstools
+php8
+php8-cli
+php8-cgi
+php8-mod-curl
+php8-mod-session
+php8-fastcgi
+sqlite3-cli
+mosquitto-client-ssl
+uhttpd
+uhttpd-mod-ubus
+rpcd
+php8-mod-pdo
+php8-mod-pdo-sqlite
+-dnsmasq
+omega2-script
+kmod-pwm-mediatek-ramips
+kmod-p44-ledchain
 "
 
 BUILD_MODELS="


### PR DESCRIPTION
1) In profile PACKAGE_REPOS env allows you to add new repositories. But running onion_buildenv update_sdk overwrite and changes made to repositories.conf with the openwrt defaults. Added - prefix to any feed in PACKAGE_REPOS, will filter out those feeds when running onion_buildenv update_sdk

2) Added env DATE_VERSION to profile, if set to "n" the date will no longer be appended to the filename of the generated firmware file

3) Deleting files from the "additions" directory tree were not reflected when building. Added new function clean_additions() to remove all additions when running update_imagebuilder